### PR TITLE
Ensure that target is set before checking its status

### DIFF
--- a/packages/@podman-desktop-companion/container-client/src/adapters/abstract.js
+++ b/packages/@podman-desktop-companion/container-client/src/adapters/abstract.js
@@ -862,7 +862,7 @@ class AbstractClientEngineSubsystemLIMA extends AbstractControlledClientEngine {
     const settings = await this.getCurrentSettings();
     const instances = await this.getControllerScopes();
     const target = instances.find((it) => it.Name === settings.controller.scope);
-    return target.Status === "Running";
+    return !!target && target.Status === "Running";
   }
   async isEngineAvailable() {
     const result = { success: true, details: "Engine is available" };


### PR DESCRIPTION
When using lima as a client engine, we need to make sure that there is a target before trying to access the status of the target.

This fixes #68 
