### PR TITLE
Fix for NPE when no podman machines exist

### DIFF
--- a/packages/@podman-desktop-companion/container-client/src/adapters/podman.js
+++ b/packages/@podman-desktop-companion/container-client/src/adapters/podman.js
@@ -230,7 +230,7 @@ class PodmanClientEngineVirtualized extends AbstractPodmanControlledClientEngine
     const settings = await this.getCurrentSettings();
     const machines = await this.getControllerScopes();
     const target = machines.find((it) => it.Name === settings.controller.scope);
-    return target.Running;
+    return target?.Running;
   }
   // Executes command inside controller scope
   async getScopedCommand(program, args, opts) {


### PR DESCRIPTION
The symptom is a blank screen on startup.

The cause is this error:
```
TypeError: Cannot read properties of undefined (reading 'Running')
at PodmanClientEngineVirtualized.isControllerScopeAvailable
```

This is because no machines exist, that is empty output of

```bash
podman machine list
```